### PR TITLE
Missing '</Class>' after first class declaration.

### DIFF
--- a/Setup/CustomCensusComponents.xml
+++ b/Setup/CustomCensusComponents.xml
@@ -12,6 +12,7 @@
 <Property name="Longitude">
 <Type>%String</Type>
 </Property>
+</Class>
 
 <Class name="Demo.GeoResponse">
 <Super>%Persistent,Ens.Util.MessageBodyMethods</Super>


### PR DESCRIPTION
Class import triggered error due to missing </Class> after first class declaration in xml.